### PR TITLE
Http only auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/bcrypt": "^5.0.0",
+        "@types/cookie-parser": "^1.4.3",
         "@types/cors": "^2.8.12",
         "@types/express": "^4.17.13",
         "@types/jsonwebtoken": "^8.5.8",
@@ -17,6 +18,7 @@
         "@types/pg": "^8.6.5",
         "bcrypt": "^5.0.1",
         "concurrently": "^7.0.0",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.0.0",
         "express": "^4.17.2",
@@ -165,6 +167,14 @@
       "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "dependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {
@@ -772,6 +782,18 @@
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/cookie-signature": {
@@ -2971,6 +2993,14 @@
         "@types/node": "*"
       }
     },
+    "@types/cookie-parser": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.3.tgz",
+      "integrity": "sha512-CqSKwFwefj4PzZ5n/iwad/bow2hTCh0FlNAeWLtQM3JA/NX/iYagIpWG2cf1bQKQ2c9gU2log5VUCrn7LDOs0w==",
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/cors": {
       "version": "2.8.12",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
@@ -3439,6 +3469,15 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/bcrypt": "^5.0.0",
+    "@types/cookie-parser": "^1.4.3",
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
     "@types/jsonwebtoken": "^8.5.8",
@@ -20,6 +21,7 @@
     "@types/pg": "^8.6.5",
     "bcrypt": "^5.0.1",
     "concurrently": "^7.0.0",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
     "express": "^4.17.2",

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,4 +1,7 @@
 // The declarations below are used for typescript's Declaration Merging
+
+import { Request } from "express"
+
 // so that a Request object also can contain an AuthUser
 export interface AuthUser {
   id: string
@@ -21,3 +24,8 @@ export type BackendError =
 export type BackendResponse =
   { success: any, code?: number } |
   BackendError
+
+// Types requests
+export interface TypedReqCookies<T> extends Request {
+  cookies: T
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -9,10 +9,16 @@ export interface AuthenticatedResponse extends Response {
 // Express middleware function. Will respond with a 403 if failed to authenticate, otherwise will add 
 // authenticated information to the request object
 export function authenticateToken(req: Request, res: AuthenticatedResponse, next: NextFunction) {
-  const authHeader = req.headers['authorization']
-  const token = authHeader && authHeader.split(" ")[1]
+  let token: string | undefined = undefined
+  // First try to get access token from cookies
+  if ("accessToken" in req.cookies) token = req.cookies.accessToken
+  else {
+    // Otherwise try to get it from the authorization header
+    const authHeader = req.headers['authorization']
+    token = authHeader && authHeader.split(" ")[1]
+  }
 
-  if (token == null) return res.status(401).json({ simpleError: "No token given", code: 401 } as BackendResponse)
+  if (!token) return res.status(401).json({ simpleError: "No token given", code: 401 } as BackendResponse)
 
   const data = Token.verifyAccToken(token)
   if (data.isValid) {

--- a/src/models/blog.ts
+++ b/src/models/blog.ts
@@ -360,7 +360,7 @@ export default class Blog {
 
       return promise
     } catch (err) {
-      throw err
+      throw { unknownError: err, code: 500 }
     }
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,17 +4,18 @@ dotenv.config()
 import express from "express"
 import cors from "cors"
 
-import { AuthUser } from "./custom"
 import { router as authRouter } from "./routes/authserver"
-import database from "./herokuClient"
 import { authenticateToken } from "./middleware/auth"
-import {router as blogRouter} from "./routes/blog"
+import { router as blogRouter } from "./routes/blog"
 
 // Start up express
 const app = express()
 app.use(express.json())
 // Setup cors
-app.use(cors())
+app.use(cors({
+  origin: "http://localhost:3000",
+  credentials: true
+}))
 
 
 interface User {


### PR DESCRIPTION
- The backend can now respond to auth requests with http only cookies, for browser frontends
- The backend can accept auth tokens from cookies
- Overall http-only auth is now available from the backend